### PR TITLE
Enhance home card slider transition

### DIFF
--- a/script.js
+++ b/script.js
@@ -347,13 +347,29 @@ function initCardSlider(cardAnchorEl, images, intervalMs = 3800){
 
   function goTo(idx){
     const nextIdx = (idx + images.length) % images.length;
+    if(nextIdx === curr) return;
+
     const preload = new Image(); preload.src = images[nextIdx];
 
-    const show = usingA ? slideB : slideA;
-    show.style.backgroundImage = `url("${images[nextIdx]}")`;
+    const incoming = usingA ? slideB : slideA;
+    const outgoing = usingA ? slideA : slideB;
 
-    slideA.classList.toggle('is-active', !usingA);
-    slideB.classList.toggle('is-active', usingA);
+    incoming.style.backgroundImage = `url("${images[nextIdx]}")`;
+
+    const handleLeaveEnd = (e)=>{
+      if(e.propertyName !== 'opacity') return;
+      outgoing.classList.remove('is-leaving');
+      outgoing.removeEventListener('transitionend', handleLeaveEnd);
+    };
+
+    outgoing.addEventListener('transitionend', handleLeaveEnd);
+
+    incoming.classList.add('is-active');
+    outgoing.classList.add('is-leaving');
+    requestAnimationFrame(()=>{
+      outgoing.classList.remove('is-active');
+    });
+
     usingA = !usingA;
     curr = nextIdx;
 

--- a/styles.css
+++ b/styles.css
@@ -183,9 +183,22 @@ h1:focus { outline: none; }
 .card-slide {
   position: absolute; inset: 0;
   background-position: center; background-size: cover; background-repeat: no-repeat;
-  opacity: 0; transition: opacity 420ms ease;
+  opacity: 0;
+  transform: scale(1.04);
+  transition: opacity 520ms ease, transform 720ms ease;
+  z-index: 0;
+  pointer-events: none;
 }
-.card-slide.is-active { opacity: 1; }
+.card-slide.is-active {
+  opacity: 1;
+  transform: scale(1);
+  z-index: 2;
+}
+.card-slide.is-leaving {
+  opacity: 0;
+  transform: scale(1.02);
+  z-index: 1;
+}
 
 /* 點點指示器 */
 .card-dots {


### PR DESCRIPTION
## Summary
- update the home card slider logic to support a smoother cross-fade hand-off between slides
- refine the card slide styling to add layered scaling and opacity transitions for a progressive overlay effect

## Testing
- Manual preview in browser

------
https://chatgpt.com/codex/tasks/task_e_68dfc053c8688322803478003c17a764