### PR TITLE
Shorten Chinese language label

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -2,7 +2,7 @@ const LANG_OPTIONS = [
   { code: 'en', label: 'English' },
   { code: 'ja', label: '日本語' },
   { code: 'ko', label: '한국어' },
-  { code: 'zh', label: '繁體中文' }
+  { code: 'zh', label: '中文' }
 ];
 
 const I18N = {
@@ -11,7 +11,7 @@ const I18N = {
     navBrandAria: '衛卡攝影影像工作室首頁',
     skipLink: '跳到主要內容',
     toastNotFound: '找不到頁面，已帶你回主頁',
-    languageName: '繁體中文',
+    languageName: '中文',
     currency: { prefix: 'NT$', locale: 'zh-TW' },
     buttons: {
       viewPlan: '查看方案',

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://weilin58.github.io/weika-pricing-site/</loc>
-    <lastmod>2025-10-13</lastmod>
+    <lastmod>2025-10-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- rename the zh locale label to the shorter "中文" so the mobile language picker fits better
- keep the zh languageName string consistent with the updated label

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68ee528243348322a0dae7bc66f6c2ab